### PR TITLE
feat: build Erin Ijesa tourism site with admin studio

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# erin-ijesa
+# Erin Ijesa Destination Experience
+
+A Next.js experience site that showcases Erin Ijesa (Olumirin Waterfalls) in Osun State, Nigeria. The site blends immersive storytelling with fully client-side content management so curators can rework copy, imagery, and media directly in the browser.
+
+## Features
+
+- **Immersive storytelling:** Hero video, cultural timeline, curated experiences, and inspirational highlights about the waterfalls and the community.
+- **Rich media gallery:** Responsive cards and galleries that accept remote URLs or locally uploaded images/videos (stored as base64 strings in the browser).
+- **In-browser admin studio:** Navigate to `/admin` to edit every section (hero, overview, culture, attractions, experiences, planning tips, gallery, footer). Upload new visuals or paste URLs and instantly preview changes on the main site.
+- **Local persistence:** Content changes are saved to `localStorage` so that updates remain on the device until reset.
+
+## Getting Started
+
+Because this environment does not allow installing npm packages, install dependencies locally first:
+
+```bash
+npm install
+```
+
+Then run the development server:
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the experience.
+
+### Editing Content
+
+1. Visit `/admin` to open the admin studio.
+2. Update text fields or upload imagery/video.
+3. Press **Save changes** to persist to your browser.
+4. Navigate back to the home page to see updates rendered immediately.
+5. Use **Reset to curated defaults** to restore the original storytelling content.
+
+## Tech Stack
+
+- [Next.js 14](https://nextjs.org/)
+- [React 18](https://react.dev/)
+- TypeScript
+- CSS modules via global stylesheet
+
+## Notes
+
+- Uploads are stored as base64 data URLs in the browser, which is ideal for demos and rapid iteration. For production, wire the admin studio to a persistent API or headless CMS.
+- Remote images from Wikimedia and Unsplash are whitelisted in `next.config.js`.

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,752 @@
+'use client';
+
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
+import { SiteContent, defaultContent } from '@/lib/defaultContent';
+import { useSiteContent } from '../context/SiteContentContext';
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (error) => reject(error);
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function AdminPage() {
+  const { content, setEntireContent, resetContent, isLoaded } = useSiteContent();
+  const [draft, setDraft] = useState<SiteContent>(content);
+  const [status, setStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isLoaded) {
+      setDraft(content);
+    }
+  }, [content, isLoaded]);
+
+  const handleHeroChange = (field: keyof SiteContent['hero'], value: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      hero: {
+        ...prev.hero,
+        [field]: value,
+      },
+    }));
+  };
+
+  const handleOverviewHighlightChange = (index: number, value: string) => {
+    setDraft((prev) => {
+      const highlights = [...prev.overview.highlights];
+      highlights[index] = value;
+      return {
+        ...prev,
+        overview: {
+          ...prev.overview,
+          highlights,
+        },
+      };
+    });
+  };
+
+  const handleTimelineChange = (index: number, field: 'title' | 'description', value: string) => {
+    setDraft((prev) => {
+      const timeline = [...prev.culture.timeline];
+      timeline[index] = {
+        ...timeline[index],
+        [field]: value,
+      };
+      return {
+        ...prev,
+        culture: {
+          ...prev.culture,
+          timeline,
+        },
+      };
+    });
+  };
+
+  const handleAttractionChange = (index: number, field: 'title' | 'description' | 'image', value: string) => {
+    setDraft((prev) => {
+      const attractions = [...prev.attractions];
+      attractions[index] = {
+        ...attractions[index],
+        [field]: value,
+      };
+      return { ...prev, attractions };
+    });
+  };
+
+  const handleExperienceChange = (index: number, field: 'title' | 'description' | 'image', value: string) => {
+    setDraft((prev) => {
+      const items = [...prev.experiences.items];
+      items[index] = {
+        ...items[index],
+        [field]: value,
+      };
+      return {
+        ...prev,
+        experiences: {
+          ...prev.experiences,
+          items,
+        },
+      };
+    });
+  };
+
+  const handlePlanningTipChange = (index: number, field: 'title' | 'description', value: string) => {
+    setDraft((prev) => {
+      const tips = [...prev.planning.tips];
+      tips[index] = {
+        ...tips[index],
+        [field]: value,
+      };
+      return {
+        ...prev,
+        planning: {
+          ...prev.planning,
+          tips,
+        },
+      };
+    });
+  };
+
+  const handleGalleryChange = (index: number, field: 'src' | 'alt', value: string) => {
+    setDraft((prev) => {
+      const items = [...prev.gallery.items];
+      items[index] = {
+        ...items[index],
+        [field]: value,
+      };
+      return {
+        ...prev,
+        gallery: {
+          ...prev.gallery,
+          items,
+        },
+      };
+    });
+  };
+
+  const handleFooterChange = (field: keyof SiteContent['footer'], value: any) => {
+    setDraft((prev) => ({
+      ...prev,
+      footer: {
+        ...prev.footer,
+        [field]: value,
+      },
+    }));
+  };
+
+  const handleSocialChange = (index: number, field: 'platform' | 'url', value: string) => {
+    setDraft((prev) => {
+      const social = [...prev.footer.social];
+      social[index] = {
+        ...social[index],
+        [field]: value,
+      };
+      return {
+        ...prev,
+        footer: {
+          ...prev.footer,
+          social,
+        },
+      };
+    });
+  };
+
+  const addHighlight = () => {
+    setDraft((prev) => ({
+      ...prev,
+      overview: {
+        ...prev.overview,
+        highlights: [...prev.overview.highlights, 'New highlight'],
+      },
+    }));
+  };
+
+  const addTimeline = () => {
+    setDraft((prev) => ({
+      ...prev,
+      culture: {
+        ...prev.culture,
+        timeline: [
+          ...prev.culture.timeline,
+          { title: 'New milestone', description: 'Describe the cultural moment.' },
+        ],
+      },
+    }));
+  };
+
+  const addAttraction = () => {
+    setDraft((prev) => ({
+      ...prev,
+      attractions: [
+        ...prev.attractions,
+        {
+          title: 'New attraction',
+          description: 'Tell visitors why this spot is special.',
+          image: '',
+        },
+      ],
+    }));
+  };
+
+  const addExperience = () => {
+    setDraft((prev) => ({
+      ...prev,
+      experiences: {
+        ...prev.experiences,
+        items: [
+          ...prev.experiences.items,
+          {
+            title: 'New experience',
+            description: 'Share the feeling this moment delivers.',
+            image: '',
+          },
+        ],
+      },
+    }));
+  };
+
+  const addPlanningTip = () => {
+    setDraft((prev) => ({
+      ...prev,
+      planning: {
+        ...prev.planning,
+        tips: [
+          ...prev.planning.tips,
+          { title: 'New travel tip', description: 'Offer practical guidance.' },
+        ],
+      },
+    }));
+  };
+
+  const addGalleryItem = () => {
+    setDraft((prev) => ({
+      ...prev,
+      gallery: {
+        ...prev.gallery,
+        items: [
+          ...prev.gallery.items,
+          { id: `gallery-${Date.now()}`, src: '', alt: 'New gallery item' },
+        ],
+      },
+    }));
+  };
+
+  const addSocialLink = () => {
+    setDraft((prev) => ({
+      ...prev,
+      footer: {
+        ...prev.footer,
+        social: [
+          ...prev.footer.social,
+          { platform: 'New platform', url: 'https://example.com' },
+        ],
+      },
+    }));
+  };
+
+  const removeItem = <T,>(items: T[], index: number) => items.filter((_, i) => i !== index);
+
+  const handleRemove = (collection: keyof SiteContent, index: number) => {
+    setDraft((prev) => {
+      if (collection === 'overview') {
+        return {
+          ...prev,
+          overview: {
+            ...prev.overview,
+            highlights: removeItem(prev.overview.highlights, index),
+          },
+        };
+      }
+      if (collection === 'culture') {
+        return {
+          ...prev,
+          culture: {
+            ...prev.culture,
+            timeline: removeItem(prev.culture.timeline, index),
+          },
+        };
+      }
+      if (collection === 'attractions') {
+        return {
+          ...prev,
+          attractions: removeItem(prev.attractions, index),
+        };
+      }
+      if (collection === 'experiences') {
+        return {
+          ...prev,
+          experiences: {
+            ...prev.experiences,
+            items: removeItem(prev.experiences.items, index),
+          },
+        };
+      }
+      if (collection === 'planning') {
+        return {
+          ...prev,
+          planning: {
+            ...prev.planning,
+            tips: removeItem(prev.planning.tips, index),
+          },
+        };
+      }
+      if (collection === 'gallery') {
+        return {
+          ...prev,
+          gallery: {
+            ...prev.gallery,
+            items: removeItem(prev.gallery.items, index),
+          },
+        };
+      }
+      if (collection === 'footer') {
+        return {
+          ...prev,
+          footer: {
+            ...prev.footer,
+            social: removeItem(prev.footer.social, index),
+          },
+        };
+      }
+      return prev;
+    });
+  };
+
+  const handleFileUpload = async (
+    event: ChangeEvent<HTMLInputElement>,
+    onValue: (value: string) => void
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const dataUrl = await readFileAsDataUrl(file);
+    onValue(dataUrl);
+    event.target.value = '';
+  };
+
+  const handleSave = () => {
+    setEntireContent(draft);
+    setStatus('Content saved to local storage. Refresh the main page to preview.');
+    setTimeout(() => setStatus(null), 4000);
+  };
+
+  const handleReset = () => {
+    resetContent();
+    setDraft(defaultContent);
+    setStatus('Content reset to curated defaults.');
+    setTimeout(() => setStatus(null), 4000);
+  };
+
+  const unsavedChanges = useMemo(() => JSON.stringify(draft) !== JSON.stringify(content), [draft, content]);
+
+  return (
+    <div className="admin-container">
+      <div className="admin-card">
+        <div>
+          <h1 style={{ fontFamily: 'var(--font-display)', fontSize: '2.5rem', margin: 0 }}>Admin Studio</h1>
+          <p style={{ marginTop: '0.5rem', maxWidth: '60ch', color: 'var(--color-muted)' }}>
+            Edit every facet of the Erin Ijesa experience. Upload new visuals, rewrite copy, and curate itineraries without
+            leaving the browser. Changes are stored locally in this device so you can iterate safely before publishing.
+          </p>
+          {status && (
+            <p style={{ marginTop: '1rem', color: 'var(--color-primary)', fontWeight: 600 }}>{status}</p>
+          )}
+        </div>
+
+        <div className="admin-grid">
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)' }}>Hero Area</h2>
+            <div className="admin-field">
+              <label htmlFor="hero-title">Title</label>
+              <input
+                id="hero-title"
+                value={draft.hero.title}
+                onChange={(event) => handleHeroChange('title', event.target.value)}
+              />
+            </div>
+            <div className="admin-field">
+              <label htmlFor="hero-subtitle">Subtitle</label>
+              <textarea
+                id="hero-subtitle"
+                value={draft.hero.subtitle}
+                onChange={(event) => handleHeroChange('subtitle', event.target.value)}
+              />
+            </div>
+            <div className="admin-field">
+              <label htmlFor="hero-cta-primary">Primary Call to Action</label>
+              <input
+                id="hero-cta-primary"
+                value={draft.hero.ctaPrimary}
+                onChange={(event) => handleHeroChange('ctaPrimary', event.target.value)}
+              />
+            </div>
+            <div className="admin-field">
+              <label htmlFor="hero-cta-secondary">Secondary Call to Action</label>
+              <input
+                id="hero-cta-secondary"
+                value={draft.hero.ctaSecondary}
+                onChange={(event) => handleHeroChange('ctaSecondary', event.target.value)}
+              />
+            </div>
+            <div className="admin-field">
+              <label htmlFor="hero-image">Hero Image</label>
+              <input
+                id="hero-image"
+                value={draft.hero.image}
+                placeholder="Paste an image URL or upload a file"
+                onChange={(event) => handleHeroChange('image', event.target.value)}
+              />
+              <input
+                type="file"
+                accept="image/*"
+                onChange={(event) => handleFileUpload(event, (value) => handleHeroChange('image', value))}
+              />
+            </div>
+            <div className="admin-field">
+              <label htmlFor="hero-video">Hero Video</label>
+              <input
+                id="hero-video"
+                value={draft.hero.video}
+                placeholder="Paste a video URL or upload"
+                onChange={(event) => handleHeroChange('video', event.target.value)}
+              />
+              <input
+                type="file"
+                accept="video/*"
+                onChange={(event) => handleFileUpload(event, (value) => handleHeroChange('video', value))}
+              />
+            </div>
+          </section>
+
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)' }}>Overview</h2>
+            <div className="admin-field">
+              <label htmlFor="overview-title">Section Title</label>
+              <input
+                id="overview-title"
+                value={draft.overview.title}
+                onChange={(event) =>
+                  setDraft((prev) => ({
+                    ...prev,
+                    overview: {
+                      ...prev.overview,
+                      title: event.target.value,
+                    },
+                  }))
+                }
+              />
+            </div>
+            <div className="admin-field">
+              <label htmlFor="overview-description">Description</label>
+              <textarea
+                id="overview-description"
+                value={draft.overview.description}
+                onChange={(event) =>
+                  setDraft((prev) => ({
+                    ...prev,
+                    overview: {
+                      ...prev.overview,
+                      description: event.target.value,
+                    },
+                  }))
+                }
+              />
+            </div>
+            {draft.overview.highlights.map((highlight, index) => (
+              <div key={`highlight-${index}`} className="admin-field">
+                <label>Highlight {index + 1}</label>
+                <textarea
+                  value={highlight}
+                  onChange={(event) => handleOverviewHighlightChange(index, event.target.value)}
+                />
+                <button
+                  type="button"
+                  className="site-nav__cta"
+                  style={{ alignSelf: 'flex-start' }}
+                  onClick={() => handleRemove('overview', index)}
+                >
+                  Remove highlight
+                </button>
+              </div>
+            ))}
+            <button type="button" className="button-secondary" onClick={addHighlight}>
+              Add highlight
+            </button>
+          </section>
+
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)' }}>Cultural Timeline</h2>
+            <p style={{ color: 'var(--color-muted)' }}>
+              Chronicle Erin Ijesa's heritage milestones. These appear as moments on the main page.
+            </p>
+            {draft.culture.timeline.map((item, index) => (
+              <div key={`timeline-${index}`} className="card" style={{ gap: '0.75rem' }}>
+                <div className="admin-field">
+                  <label>Title</label>
+                  <input
+                    value={item.title}
+                    onChange={(event) => handleTimelineChange(index, 'title', event.target.value)}
+                  />
+                </div>
+                <div className="admin-field">
+                  <label>Description</label>
+                  <textarea
+                    value={item.description}
+                    onChange={(event) => handleTimelineChange(index, 'description', event.target.value)}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="site-nav__cta"
+                  style={{ alignSelf: 'flex-start' }}
+                  onClick={() => handleRemove('culture', index)}
+                >
+                  Remove moment
+                </button>
+              </div>
+            ))}
+            <button type="button" className="button-secondary" onClick={addTimeline}>
+              Add timeline moment
+            </button>
+          </section>
+
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)' }}>Attractions</h2>
+            {draft.attractions.map((attraction, index) => (
+              <div key={`attraction-${index}`} className="card" style={{ gap: '1rem' }}>
+                <div className="admin-field">
+                  <label>Title</label>
+                  <input
+                    value={attraction.title}
+                    onChange={(event) => handleAttractionChange(index, 'title', event.target.value)}
+                  />
+                </div>
+                <div className="admin-field">
+                  <label>Description</label>
+                  <textarea
+                    value={attraction.description}
+                    onChange={(event) => handleAttractionChange(index, 'description', event.target.value)}
+                  />
+                </div>
+                <div className="admin-field">
+                  <label>Image</label>
+                  <input
+                    value={attraction.image}
+                    placeholder="Image URL"
+                    onChange={(event) => handleAttractionChange(index, 'image', event.target.value)}
+                  />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(event) =>
+                      handleFileUpload(event, (value) => handleAttractionChange(index, 'image', value))
+                    }
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="site-nav__cta"
+                  style={{ alignSelf: 'flex-start' }}
+                  onClick={() => handleRemove('attractions', index)}
+                >
+                  Remove attraction
+                </button>
+              </div>
+            ))}
+            <button type="button" className="button-secondary" onClick={addAttraction}>
+              Add attraction
+            </button>
+          </section>
+
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)' }}>Experiences</h2>
+            {draft.experiences.items.map((item, index) => (
+              <div key={`experience-${index}`} className="card" style={{ gap: '1rem' }}>
+                <div className="admin-field">
+                  <label>Title</label>
+                  <input
+                    value={item.title}
+                    onChange={(event) => handleExperienceChange(index, 'title', event.target.value)}
+                  />
+                </div>
+                <div className="admin-field">
+                  <label>Description</label>
+                  <textarea
+                    value={item.description}
+                    onChange={(event) => handleExperienceChange(index, 'description', event.target.value)}
+                  />
+                </div>
+                <div className="admin-field">
+                  <label>Image</label>
+                  <input
+                    value={item.image ?? ''}
+                    onChange={(event) => handleExperienceChange(index, 'image', event.target.value)}
+                    placeholder="Image URL"
+                  />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(event) =>
+                      handleFileUpload(event, (value) => handleExperienceChange(index, 'image', value))
+                    }
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="site-nav__cta"
+                  style={{ alignSelf: 'flex-start' }}
+                  onClick={() => handleRemove('experiences', index)}
+                >
+                  Remove experience
+                </button>
+              </div>
+            ))}
+            <button type="button" className="button-secondary" onClick={addExperience}>
+              Add experience
+            </button>
+          </section>
+
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)' }}>Planning Tips</h2>
+            {draft.planning.tips.map((tip, index) => (
+              <div key={`tip-${index}`} className="card" style={{ gap: '1rem' }}>
+                <div className="admin-field">
+                  <label>Title</label>
+                  <input
+                    value={tip.title}
+                    onChange={(event) => handlePlanningTipChange(index, 'title', event.target.value)}
+                  />
+                </div>
+                <div className="admin-field">
+                  <label>Description</label>
+                  <textarea
+                    value={tip.description}
+                    onChange={(event) => handlePlanningTipChange(index, 'description', event.target.value)}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="site-nav__cta"
+                  style={{ alignSelf: 'flex-start' }}
+                  onClick={() => handleRemove('planning', index)}
+                >
+                  Remove tip
+                </button>
+              </div>
+            ))}
+            <button type="button" className="button-secondary" onClick={addPlanningTip}>
+              Add tip
+            </button>
+          </section>
+
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)' }}>Gallery</h2>
+            {draft.gallery.items.map((item, index) => (
+              <div key={item.id} className="card" style={{ gap: '1rem' }}>
+                <div className="admin-field">
+                  <label>Image Source</label>
+                  <input
+                    value={item.src}
+                    onChange={(event) => handleGalleryChange(index, 'src', event.target.value)}
+                    placeholder="Image URL"
+                  />
+                  <input
+                    type="file"
+                    accept="image/*"
+                    onChange={(event) =>
+                      handleFileUpload(event, (value) => handleGalleryChange(index, 'src', value))
+                    }
+                  />
+                </div>
+                <div className="admin-field">
+                  <label>Alt text</label>
+                  <input
+                    value={item.alt}
+                    onChange={(event) => handleGalleryChange(index, 'alt', event.target.value)}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="site-nav__cta"
+                  style={{ alignSelf: 'flex-start' }}
+                  onClick={() => handleRemove('gallery', index)}
+                >
+                  Remove gallery item
+                </button>
+              </div>
+            ))}
+            <button type="button" className="button-secondary" onClick={addGalleryItem}>
+              Add gallery item
+            </button>
+          </section>
+
+          <section>
+            <h2 style={{ fontFamily: 'var(--font-display)' }}>Footer</h2>
+            <div className="admin-field">
+              <label htmlFor="footer-email">Contact email</label>
+              <input
+                id="footer-email"
+                value={draft.footer.contactEmail}
+                onChange={(event) => handleFooterChange('contactEmail', event.target.value)}
+              />
+            </div>
+            <div className="admin-field">
+              <label htmlFor="footer-address">Address</label>
+              <textarea
+                id="footer-address"
+                value={draft.footer.address}
+                onChange={(event) => handleFooterChange('address', event.target.value)}
+              />
+            </div>
+            {draft.footer.social.map((item, index) => (
+              <div key={`social-${index}`} className="card" style={{ gap: '1rem' }}>
+                <div className="admin-field">
+                  <label>Platform</label>
+                  <input
+                    value={item.platform}
+                    onChange={(event) => handleSocialChange(index, 'platform', event.target.value)}
+                  />
+                </div>
+                <div className="admin-field">
+                  <label>URL</label>
+                  <input
+                    value={item.url}
+                    onChange={(event) => handleSocialChange(index, 'url', event.target.value)}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="site-nav__cta"
+                  style={{ alignSelf: 'flex-start' }}
+                  onClick={() => handleRemove('footer', index)}
+                >
+                  Remove social link
+                </button>
+              </div>
+            ))}
+            <button type="button" className="button-secondary" onClick={addSocialLink}>
+              Add social link
+            </button>
+          </section>
+        </div>
+
+        <div className="admin-actions">
+          <button type="button" className="reset" onClick={handleReset}>
+            Reset to curated defaults
+          </button>
+          <button
+            type="button"
+            className="save"
+            onClick={handleSave}
+            disabled={!unsavedChanges}
+            style={{ opacity: unsavedChanges ? 1 : 0.6 }}
+          >
+            {unsavedChanges ? 'Save changes' : 'All changes saved'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/HomeContent.tsx
+++ b/app/components/HomeContent.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import Image from 'next/image';
+import { useMemo } from 'react';
+import { useSiteContent } from '../context/SiteContentContext';
+
+function isDataUrl(src: string) {
+  return src.startsWith('data:');
+}
+
+export default function HomeContent() {
+  const { content } = useSiteContent();
+
+  const immersionVideo = useMemo(() => content.hero.video, [content.hero.video]);
+
+  return (
+    <>
+      <section className="hero" id="hero">
+        <div className="hero-media" aria-hidden="true">
+          {immersionVideo ? (
+            <video
+              className="embed-responsive"
+              src={immersionVideo}
+              autoPlay
+              loop
+              muted
+              playsInline
+              poster={content.hero.image}
+            />
+          ) : (
+            <Image
+              src={content.hero.image}
+              alt="Erin Ijesa waterfall"
+              fill
+              priority
+              sizes="100vw"
+              style={{ objectFit: 'cover' }}
+              unoptimized={isDataUrl(content.hero.image)}
+            />
+          )}
+        </div>
+        <div className="hero-content">
+          <div>
+            <p className="tag">Destination Spotlight</p>
+            <h1>{content.hero.title}</h1>
+            <p>{content.hero.subtitle}</p>
+            <div className="cta-group">
+              <a href="#planning" className="button-primary">
+                {content.hero.ctaPrimary}
+              </a>
+              <a href="#attractions" className="button-secondary">
+                {content.hero.ctaSecondary}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="overview">
+        <div className="section-heading">
+          <h2>{content.overview.title}</h2>
+          <p>{content.overview.description}</p>
+        </div>
+        <div className="card-grid">
+          {content.overview.highlights.map((highlight, index) => (
+            <div key={index} className="card">
+              <h3>Signature Highlight {index + 1}</h3>
+              <p>{highlight}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="culture">
+        <div className="section-heading">
+          <h2>{content.culture.title}</h2>
+          <p>{content.culture.description}</p>
+        </div>
+        <div className="timeline">
+          {content.culture.timeline.map((item, index) => (
+            <div key={`${item.title}-${index}`} className="timeline-item">
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="attractions">
+        <div className="section-heading">
+          <h2>Flagship Attractions</h2>
+          <p>
+            From the thundering cascades to tranquil forest groves, Erin Ijesa rewards every explorer with layered
+            adventures.
+          </p>
+        </div>
+        <div className="card-grid">
+          {content.attractions.map((attraction) => (
+            <div key={attraction.title} className="card">
+              <div className="gallery-item" style={{ height: 220 }}>
+                <Image
+                  src={attraction.image}
+                  alt={attraction.title}
+                  fill
+                  sizes="(max-width: 768px) 100vw, 33vw"
+                  style={{ objectFit: 'cover' }}
+                  unoptimized={isDataUrl(attraction.image)}
+                />
+              </div>
+              <div>
+                <h3>{attraction.title}</h3>
+                <p>{attraction.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="experiences">
+        <div className="section-heading">
+          <h2>{content.experiences.title}</h2>
+          <p>{content.experiences.description}</p>
+        </div>
+        <div className="card-grid">
+          {content.experiences.items.map((item) => (
+            <div key={item.title} className="card">
+              {item.image && (
+                <div className="gallery-item" style={{ height: 200 }}>
+                  <Image
+                    src={item.image}
+                    alt={item.title}
+                    fill
+                    sizes="(max-width: 768px) 100vw, 33vw"
+                    style={{ objectFit: 'cover' }}
+                    unoptimized={isDataUrl(item.image ?? '')}
+                  />
+                </div>
+              )}
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="immersive-video">
+        <div className="section-heading">
+          <h2>Feel the Mist</h2>
+          <p>
+            Watch the cascades roar to life. This cinematic reel captures the serenity and exhilaration of tracing the Olumirin
+            terraces at dawn.
+          </p>
+        </div>
+        <div className="video-frame">
+          {immersionVideo ? (
+            <video
+              className="embed-responsive"
+              src={immersionVideo}
+              controls
+              playsInline
+              poster={content.hero.image}
+            />
+          ) : (
+            <div
+              style={{
+                display: 'grid',
+                placeItems: 'center',
+                height: '100%',
+                background: 'linear-gradient(135deg, rgba(15,118,110,0.45), rgba(15,23,42,0.85))',
+                color: '#fff',
+                textAlign: 'center',
+                padding: '2rem',
+              }}
+            >
+              <p style={{ maxWidth: '40ch', fontSize: '1.1rem', lineHeight: 1.8 }}>
+                Upload a signature waterfall video in the admin studio to bring Erin Ijesa to life.
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section id="planning">
+        <div className="section-heading">
+          <h2>{content.planning.title}</h2>
+          <p>{content.planning.description}</p>
+        </div>
+        <div className="card-grid">
+          {content.planning.tips.map((tip) => (
+            <div key={tip.title} className="card">
+              <h3>{tip.title}</h3>
+              <p>{tip.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="gallery">
+        <div className="section-heading">
+          <h2>{content.gallery.title}</h2>
+          <p>{content.gallery.description}</p>
+        </div>
+        <div className="gallery">
+          {content.gallery.items.map((item) => (
+            <div key={item.id} className="gallery-item" style={{ aspectRatio: '4 / 5' }}>
+              <Image
+                src={item.src}
+                alt={item.alt}
+                fill
+                sizes="(max-width: 768px) 100vw, 25vw"
+                style={{ objectFit: 'cover' }}
+                unoptimized={isDataUrl(item.src)}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/components/SiteFooter.tsx
+++ b/app/components/SiteFooter.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useSiteContent } from '../context/SiteContentContext';
+
+export default function SiteFooter() {
+  const { content } = useSiteContent();
+  const { footer } = content;
+
+  return (
+    <footer>
+      <div className="footer-content">
+        <div>
+          <h3 style={{ fontFamily: 'var(--font-display)', fontSize: '1.75rem', marginBottom: '0.5rem' }}>
+            Visit Erin Ijesa
+          </h3>
+          <p style={{ margin: 0, maxWidth: '60ch' }}>{footer.address}</p>
+          <p style={{ margin: '0.75rem 0 0' }}>Email: {footer.contactEmail}</p>
+        </div>
+        <div>
+          <p style={{ marginBottom: '0.5rem', textTransform: 'uppercase', letterSpacing: '0.2em', fontSize: '0.8rem' }}>
+            Follow the Journey
+          </p>
+          <div className="tag-list">
+            {footer.social.map((item) => (
+              <a key={item.platform} className="tag" href={item.url} target="_blank" rel="noreferrer">
+                {item.platform}
+              </a>
+            ))}
+          </div>
+        </div>
+        <p style={{ marginTop: '1.5rem', fontSize: '0.85rem', opacity: 0.8 }}>
+          © {new Date().getFullYear()} Erin Ijesa Destination Collective. All rights reserved.
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/app/components/SiteHeader.tsx
+++ b/app/components/SiteHeader.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+
+const navLinks = [
+  { href: '#overview', label: 'Discover' },
+  { href: '#attractions', label: 'Attractions' },
+  { href: '#experiences', label: 'Experiences' },
+  { href: '#planning', label: 'Plan a Visit' },
+  { href: '#gallery', label: 'Gallery' },
+];
+
+export default function SiteHeader() {
+  return (
+    <header className="site-header">
+      <div className="site-header__inner">
+        <Link href="/" className="brand">
+          <span className="brand-mark">Erin Ijesa</span>
+          <span className="brand-sub">Olumirin Waterfalls</span>
+        </Link>
+        <nav className="site-nav">
+          {navLinks.map((link) => (
+            <a key={link.href} href={link.href} className="site-nav__link">
+              {link.label}
+            </a>
+          ))}
+          <Link href="/admin" className="site-nav__cta">
+            Admin Studio
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/app/context/SiteContentContext.tsx
+++ b/app/context/SiteContentContext.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { SiteContent, defaultContent } from '@/lib/defaultContent';
+
+const STORAGE_KEY = 'erin-ijesa-site-content';
+
+type SiteContentContextValue = {
+  content: SiteContent;
+  isLoaded: boolean;
+  setEntireContent: (content: SiteContent) => void;
+  updateSection: <K extends keyof SiteContent>(section: K, value: SiteContent[K]) => void;
+  resetContent: () => void;
+};
+
+const SiteContentContext = createContext<SiteContentContextValue | null>(null);
+
+function mergeContent(partial: Partial<SiteContent>): SiteContent {
+  return {
+    ...defaultContent,
+    ...partial,
+    hero: {
+      ...defaultContent.hero,
+      ...partial.hero,
+    },
+    overview: {
+      ...defaultContent.overview,
+      ...partial.overview,
+    },
+    culture: {
+      ...defaultContent.culture,
+      ...partial.culture,
+      timeline: partial.culture?.timeline ?? defaultContent.culture.timeline,
+    },
+    experiences: {
+      ...defaultContent.experiences,
+      ...partial.experiences,
+      items: partial.experiences?.items ?? defaultContent.experiences.items,
+    },
+    planning: {
+      ...defaultContent.planning,
+      ...partial.planning,
+      tips: partial.planning?.tips ?? defaultContent.planning.tips,
+    },
+    gallery: {
+      ...defaultContent.gallery,
+      ...partial.gallery,
+      items: partial.gallery?.items ?? defaultContent.gallery.items,
+    },
+    footer: {
+      ...defaultContent.footer,
+      ...partial.footer,
+      social: partial.footer?.social ?? defaultContent.footer.social,
+    },
+    attractions: partial.attractions ?? defaultContent.attractions,
+  };
+}
+
+export function SiteContentProvider({ children }: { children: React.ReactNode }) {
+  const [content, setContent] = useState<SiteContent>(defaultContent);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    try {
+      const saved = window.localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved) as Partial<SiteContent>;
+        setContent(mergeContent(parsed));
+      }
+    } catch (error) {
+      console.warn('Unable to read saved site content', error);
+    } finally {
+      setIsLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isLoaded || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(content));
+    } catch (error) {
+      console.warn('Unable to persist site content', error);
+    }
+  }, [content, isLoaded]);
+
+  const value = useMemo<SiteContentContextValue>(
+    () => ({
+      content,
+      isLoaded,
+      setEntireContent: setContent,
+      updateSection: (section, value) => {
+        setContent((prev) => ({
+          ...prev,
+          [section]: value,
+        }));
+      },
+      resetContent: () => setContent(defaultContent),
+    }),
+    [content, isLoaded]
+  );
+
+  return <SiteContentContext.Provider value={value}>{children}</SiteContentContext.Provider>;
+}
+
+export function useSiteContent() {
+  const context = useContext(SiteContentContext);
+  if (!context) {
+    throw new Error('useSiteContent must be used within a SiteContentProvider');
+  }
+  return context;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,506 @@
+:root {
+  color-scheme: light dark;
+  --color-primary: #0f766e;
+  --color-secondary: #f97316;
+  --color-background: #f8fafc;
+  --color-surface: rgba(255, 255, 255, 0.82);
+  --color-text: #0f172a;
+  --color-muted: #475569;
+  --max-width: 1280px;
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow-lg: 0 28px 60px rgba(15, 23, 42, 0.18);
+  --shadow-sm: 0 10px 24px rgba(15, 23, 42, 0.12);
+  font-family: var(--font-sans);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+body {
+  min-height: 100vh;
+  background-image: radial-gradient(circle at top left, rgba(15, 118, 110, 0.18), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(249, 115, 22, 0.25), transparent 40%);
+  backdrop-filter: blur(20px);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  width: 100%;
+}
+
+section {
+  margin: 0 auto;
+  max-width: var(--max-width);
+  padding: 4rem 1.5rem;
+}
+
+section + section {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  background: linear-gradient(145deg, rgba(15, 118, 110, 0.85), rgba(15, 23, 42, 0.8));
+  color: white;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.2), rgba(15, 23, 42, 0.65));
+  z-index: 1;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 2;
+  padding: 5rem clamp(1.5rem, 5vw, 6rem);
+  display: grid;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2.8rem, 7vw, 5rem);
+  line-height: 1.05;
+  margin: 0;
+}
+
+.hero p {
+  font-size: clamp(1.125rem, 2vw, 1.5rem);
+  max-width: 48ch;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.hero .cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.button-primary,
+.button-secondary {
+  border-radius: 999px;
+  padding: 0.85rem 1.8rem;
+  font-weight: 600;
+  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, #f97316, #fb923c);
+  color: #fff;
+  box-shadow: 0 18px 38px rgba(249, 115, 22, 0.35);
+}
+
+.button-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(249, 115, 22, 0.45);
+}
+
+.button-secondary {
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.button-secondary:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.hero-media {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.hero-media img,
+.hero-media video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 2.5rem;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1rem;
+  backdrop-filter: blur(12px);
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-family: var(--font-display);
+  color: var(--color-primary);
+}
+
+.card p {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.65;
+}
+
+.gallery {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 2rem;
+}
+
+.gallery-item {
+  position: relative;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.gallery-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0), rgba(15, 23, 42, 0.35));
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.gallery-item:hover img {
+  transform: scale(1.05);
+}
+
+.gallery-item:hover::after {
+  opacity: 1;
+}
+
+.section-heading {
+  text-align: center;
+  margin: 0 auto 2.5rem;
+  max-width: 760px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-family: var(--font-display);
+}
+
+.section-heading p {
+  color: var(--color-muted);
+  font-size: 1.1rem;
+  line-height: 1.7;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+  position: relative;
+  padding-left: 1rem;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(15, 118, 110, 0.4), rgba(249, 115, 22, 0.4));
+}
+
+.timeline-item {
+  padding-left: 2.5rem;
+  position: relative;
+}
+
+.timeline-item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.5rem;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #0f766e, #14b8a6);
+  box-shadow: 0 10px 20px rgba(15, 118, 110, 0.35);
+}
+
+.timeline-item h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-family: var(--font-display);
+}
+
+.timeline-item p {
+  margin: 0.5rem 0 0;
+  color: var(--color-muted);
+  line-height: 1.65;
+}
+
+footer {
+  background: rgba(15, 23, 42, 0.92);
+  color: rgba(255, 255, 255, 0.85);
+  padding: 3rem 1.5rem 4rem;
+  margin-top: 4rem;
+}
+
+footer .footer-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  justify-items: center;
+  text-align: center;
+}
+
+footer a {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.admin-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+.admin-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 2rem;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.admin-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.admin-field {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.admin-field label {
+  font-weight: 600;
+  color: var(--color-primary);
+  font-family: var(--font-display);
+}
+
+.admin-field input,
+.admin-field textarea,
+.admin-field select {
+  border: 1px solid rgba(15, 118, 110, 0.25);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.admin-field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.admin-field input:focus,
+.admin-field textarea:focus,
+.admin-field select:focus {
+  outline: none;
+  border-color: rgba(249, 115, 22, 0.6);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.15);
+}
+
+.admin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+.admin-actions button {
+  border: none;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 0.85rem 1.75rem;
+  font-weight: 600;
+  font-size: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.admin-actions .save {
+  background: linear-gradient(135deg, #0f766e, #14b8a6);
+  color: #fff;
+  box-shadow: 0 18px 35px rgba(15, 118, 110, 0.35);
+}
+
+.admin-actions .reset {
+  background: rgba(15, 23, 42, 0.05);
+  color: var(--color-text);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  padding: 0.35rem 0.75rem;
+  background: rgba(15, 118, 110, 0.12);
+  color: #0f766e;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.video-frame {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  background: #000;
+  aspect-ratio: 16 / 9;
+}
+
+.embed-responsive {
+  width: 100%;
+  height: 100%;
+}
+
+@media (max-width: 768px) {
+  section {
+    padding: 3rem 1.25rem;
+  }
+
+  .hero-content {
+    padding: 4rem 1.5rem;
+  }
+
+  footer {
+    padding: 3rem 1.25rem;
+  }
+}
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(18px);
+  background: rgba(248, 250, 252, 0.82);
+  border-bottom: 1px solid rgba(15, 118, 110, 0.12);
+}
+
+.site-header__inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+}
+
+.brand {
+  display: grid;
+  gap: 0.2rem;
+  font-weight: 700;
+}
+
+.brand-mark {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  letter-spacing: 0.04em;
+  color: var(--color-primary);
+}
+
+.brand-sub {
+  font-size: 0.85rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-nav__link {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.65);
+  transition: color 0.2s ease;
+}
+
+.site-nav__link:hover {
+  color: var(--color-primary);
+}
+
+.site-nav__cta {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 118, 110, 0.25);
+  color: var(--color-primary);
+  font-weight: 700;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.site-nav__cta:hover {
+  transform: translateY(-1px);
+  background: rgba(15, 118, 110, 0.1);
+  box-shadow: 0 12px 24px rgba(15, 118, 110, 0.25);
+}
+
+@media (max-width: 900px) {
+  .site-nav {
+    display: none;
+  }
+
+  .site-header__inner {
+    justify-content: center;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { Manrope, Playfair_Display } from 'next/font/google';
+import './globals.css';
+import { SiteContentProvider } from './context/SiteContentContext';
+import SiteHeader from './components/SiteHeader';
+import SiteFooter from './components/SiteFooter';
+
+const manrope = Manrope({ subsets: ['latin'], variable: '--font-sans' });
+const playfair = Playfair_Display({ subsets: ['latin'], variable: '--font-display' });
+
+export const metadata: Metadata = {
+  title: 'Erin Ijesa — Olumirin Waterfalls & Cultural Escape',
+  description:
+    'Discover Erin Ijesa in Osun State, Nigeria. Explore the majestic Olumirin Waterfalls, Yoruba heritage, eco-adventures, and plan your next getaway.',
+  keywords: [
+    'Erin Ijesa',
+    'Olumirin Waterfalls',
+    'Osun State tourism',
+    'Nigeria travel',
+    'Yoruba culture',
+  ],
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={`${manrope.variable} ${playfair.variable}`}>
+        <SiteContentProvider>
+          <SiteHeader />
+          <main>{children}</main>
+          <SiteFooter />
+        </SiteContentProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,7 @@
+import dynamic from 'next/dynamic';
+
+const HomeContent = dynamic(() => import('./components/HomeContent'), { ssr: false });
+
+export default function Page() {
+  return <HomeContent />;
+}

--- a/lib/defaultContent.ts
+++ b/lib/defaultContent.ts
@@ -1,0 +1,212 @@
+export type Highlight = {
+  title: string;
+  description: string;
+  image?: string;
+};
+
+export type TravelTip = {
+  title: string;
+  description: string;
+};
+
+export type GalleryItem = {
+  id: string;
+  src: string;
+  alt: string;
+};
+
+export type Attraction = {
+  title: string;
+  description: string;
+  image: string;
+};
+
+export type SiteContent = {
+  hero: {
+    title: string;
+    subtitle: string;
+    image: string;
+    video: string;
+    ctaPrimary: string;
+    ctaSecondary: string;
+  };
+  overview: {
+    title: string;
+    description: string;
+    highlights: string[];
+  };
+  culture: {
+    title: string;
+    description: string;
+    timeline: Highlight[];
+  };
+  attractions: Attraction[];
+  experiences: {
+    title: string;
+    description: string;
+    items: Highlight[];
+  };
+  planning: {
+    title: string;
+    description: string;
+    tips: TravelTip[];
+  };
+  gallery: {
+    title: string;
+    description: string;
+    items: GalleryItem[];
+  };
+  footer: {
+    contactEmail: string;
+    address: string;
+    social: { platform: string; url: string }[];
+  };
+};
+
+export const defaultContent: SiteContent = {
+  hero: {
+    title: "Erin Ijesa",
+    subtitle:
+      "Discover the soul of Osun State at the Olumirin Waterfalls—where lush forests, cascading waters, and rich Yoruba heritage converge to create Nigeria's most enchanting highland escape.",
+    image: "https://upload.wikimedia.org/wikipedia/commons/7/71/Erin_Ijesha_Waterfalls.jpg",
+    video:
+      "https://res.cloudinary.com/da6hlzz0s/video/upload/v1689870760/samples/landscapes/forest-waterfall.mp4",
+    ctaPrimary: "Plan Your Adventure",
+    ctaSecondary: "Explore the Waterfalls",
+  },
+  overview: {
+    title: "A Cascading Oasis in the Yoruba Highlands",
+    description:
+      "Tucked within the undulating ridges that separate Erin-Oke and Erin-Ijesa, the Olumirin Waterfalls descend in seven dramatic tiers, each unveiling a new plunge pool, a new vista, and a new story. Since its first recorded sighting in 1140 AD by hunters from Ile-Ife, the falls have been revered as a sacred sanctuary where nature and spirituality flow together.",
+    highlights: [
+      "Seven-level waterfalls enveloped by evergreen forest canopies.",
+      "Gateway to the ancient trade routes of the Ijesa people.",
+      "Hub for eco-tourism, adventure hiking, and cultural immersion.",
+    ],
+  },
+  culture: {
+    title: "Living Culture & Heritage",
+    description:
+      "Erin Ijesa is more than its waterfalls—it is a living museum of Yoruba customs. From annual festivals honouring the river goddess to the melodious rhythms of talking drums echoing through the valleys, the community keeps centuries-old traditions vibrantly alive.",
+    timeline: [
+      {
+        title: "Origins in the 12th Century",
+        description:
+          "Legend narrates that Olumirin, the waterfall spirit, guided migrants from Ile-Ife to settle around the cascading waters, founding Erin Ijesa as a place of refuge and renewal.",
+      },
+      {
+        title: "Royal Connections",
+        description:
+          "The town maintains deep ties with the Owa Obokun of Ijesaland, and palace ceremonies often commence with libations at the waterfalls to invoke blessings.",
+      },
+      {
+        title: "Festivals of Light",
+        description:
+          "During the annual Olumirin Festival, the community adorns the terraces with lanterns, drumming, and dance, transforming the falls into a glowing amphitheatre of culture.",
+      },
+    ],
+  },
+  attractions: [
+    {
+      title: "Olumirin Waterfalls",
+      description:
+        "Ascend through seven waterfalls, each with its own crystal-clear plunge pool and cooling mist. The third level offers panoramic views of the Ijesa countryside, while the seventh rewards daring hikers with tranquil silence.",
+      image: "https://upload.wikimedia.org/wikipedia/commons/d/dc/Erin_Ijesha_Waterfalls_steps.jpg",
+    },
+    {
+      title: "Sacred Grove Trails",
+      description:
+        "Follow forest paths lined with medicinal plants, silk-cotton trees, and shrines where priestesses offer prayers to Olumirin. Guided tours share the ecological and spiritual significance of the grove.",
+      image: "https://images.unsplash.com/photo-1469474968028-56623f02e42e",
+    },
+    {
+      title: "Ijesa Culinary Evenings",
+      description:
+        "Savour farm-to-table delicacies like pounded yam, egusi, and locally fermented palm wine at twilight markets hosted by Erin Ijesa's women cooperatives.",
+      image: "https://images.unsplash.com/photo-1555992336-cbf3cd1b79d3",
+    },
+  ],
+  experiences: {
+    title: "Why Travellers Love Erin Ijesa",
+    description:
+      "Whether you seek adrenaline, cultural immersion, or mindful restoration, Erin Ijesa curates unforgettable experiences with the warmth of Yoruba hospitality.",
+    items: [
+      {
+        title: "Adventure & Wellness",
+        description:
+          "Guided cliff hikes, rainforest yoga, and waterfall hydrotherapy sessions create holistic retreats that refresh body and spirit.",
+        image: "https://images.unsplash.com/photo-1470770841072-f978cf4d019e",
+      },
+      {
+        title: "Community Homestays",
+        description:
+          "Stay with artisan families, learn indigo dyeing, and join moonlit storytelling circles where elders share myths of Olumirin.",
+        image: "https://images.unsplash.com/photo-1524492412937-b28074a5d7da",
+      },
+      {
+        title: "Birdwatching Haven",
+        description:
+          "Spot rare species like the white-throated bee-eater and African paradise flycatcher fluttering across the canyons at dawn.",
+        image: "https://images.unsplash.com/photo-1444464666168-49d633b86797",
+      },
+    ],
+  },
+  planning: {
+    title: "Plan Your Journey",
+    description:
+      "Navigate your trip with insider insights from local guides. Erin Ijesa welcomes explorers all year round, with cascading intensity peaking after the rains.",
+    tips: [
+      {
+        title: "Best Time to Visit",
+        description:
+          "July to October offers the fullest waterfalls, while November to February delivers cooler hikes and clear sunrise views.",
+      },
+      {
+        title: "Getting There",
+        description:
+          "Located 2.5 hours from Lagos and 45 minutes from Osogbo. Private shuttles from Akure Airport can be arranged with community tour operators.",
+      },
+      {
+        title: "What to Pack",
+        description:
+          "Lightweight hiking gear, water shoes for the pools, eco-friendly insect repellent, and a camera to capture the golden hour glow.",
+      },
+    ],
+  },
+  gallery: {
+    title: "Postcards from Erin Ijesa",
+    description:
+      "A visual diary of misty mornings, radiant smiles, and the emerald embrace of Osun State's highlands.",
+    items: [
+      {
+        id: "gallery-1",
+        src: "https://upload.wikimedia.org/wikipedia/commons/7/71/Erin_Ijesha_Waterfalls.jpg",
+        alt: "Visitors at the base of Olumirin Waterfalls",
+      },
+      {
+        id: "gallery-2",
+        src: "https://upload.wikimedia.org/wikipedia/commons/d/dc/Erin_Ijesha_Waterfalls_steps.jpg",
+        alt: "Stone steps leading through Erin Ijesa's lush forest",
+      },
+      {
+        id: "gallery-3",
+        src: "https://upload.wikimedia.org/wikipedia/commons/5/57/Olumirin_Waterfalls.jpg",
+        alt: "Upper cascade of the Olumirin Waterfalls",
+      },
+      {
+        id: "gallery-4",
+        src: "https://images.unsplash.com/photo-1489515217757-5fd1be406fef",
+        alt: "Sunlight breaking through a tropical forest canopy",
+      },
+    ],
+  },
+  footer: {
+    contactEmail: "hello@erinijesaexperiences.com",
+    address: "Olumirin Waterfalls Road, Erin Ijesa, Osun State, Nigeria",
+    social: [
+      { platform: "Instagram", url: "https://www.instagram.com/explore/tags/erinijesa/" },
+      { platform: "YouTube", url: "https://www.youtube.com/results?search_query=erin+ijesa" },
+      { platform: "Facebook", url: "https://www.facebook.com/hashtag/erinijesa" },
+    ],
+  },
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,21 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'upload.wikimedia.org',
+      },
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+      },
+    ],
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "erin-ijesa",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "autoprefixer": "10.4.17",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 14 application for the Erin Ijesa destination experience with immersive storytelling sections
- add a client-side content context with curated default data, localStorage persistence, and a rich home page layout with hero, attractions, culture, and gallery sections
- implement an admin studio at /admin for editing all content, uploading media, and managing highlights, attractions, tips, and footer links from the browser

## Testing
- Not run (npm dependencies unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e322d1add4832ba61a3d88c262c026